### PR TITLE
TRITON-2526: Add option to configure remote write

### DIFF
--- a/bin/prometheus-configure
+++ b/bin/prometheus-configure
@@ -317,6 +317,9 @@ function prometheus_configure_update_config() {
         CMON_INSECURE='true'
     fi
 
+    PROMETHEUS_REMOTE_WRITE_URL=$(json -f "${CONFIG_JSON}" \
+        prometheus_remote_write_url)
+
     SCRAPE_INTERVAL=$(json -f "${CONFIG_JSON}" scrape_interval)
     if [[ -z "${SCRAPE_INTERVAL}" ]]; then
         SCRAPE_INTERVAL=${DEFAULT_SCRAPE_INTERVAL}
@@ -336,7 +339,7 @@ function prometheus_configure_update_config() {
         "${TEMPLATES_DIR}/${FLAVOR}-$(basename ${PROMETHEUS_YML}).in" \
         UPDATES_MADE PROM_USER DATACENTER_NAME CMON_CERT_FILE CMON_KEY_FILE \
         CMON_INSECURE CMON_DOMAIN SCRAPE_INTERVAL SCRAPE_TIMEOUT \
-        EVALUATION_INTERVAL
+        EVALUATION_INTERVAL PROMETHEUS_REMOTE_WRITE_URL
 
     return 0
 }

--- a/etc/manta-prometheus.yml.in
+++ b/etc/manta-prometheus.yml.in
@@ -41,3 +41,6 @@ scrape_configs:
     static_configs:
     - targets:
       - localhost:9090
+
+remote_write:
+  url: '%%PROMETHEUS_REMOTE_WRITE_URL%%'

--- a/sapi_manifests/prometheus/template
+++ b/sapi_manifests/prometheus/template
@@ -5,6 +5,9 @@
 {{#cmon_enforce_certificate}}
     "cmon_enforce_certificate": {{{cmon_enforce_certificate}}},
 {{/cmon_enforce_certificate}}
+{{#prometheus_remote_write_url}}
+    "prometheus_remote_write_url": "{{{prometheus_remote_write_url}}}",
+{{/prometheus_remote_write_url}}
 
 {{#scrape_interval}}
     "scrape_interval": {{{scrape_interval}}},


### PR DESCRIPTION
This adds a new SAPI metadata option to allow `triton-prometheus` to send metrics to another remote prometheus using [remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
